### PR TITLE
Target .NET 4.5.1 as well as .NET Standard 1.6

### DIFF
--- a/src/Stormpath.AspNetCore/project.json
+++ b/src/Stormpath.AspNetCore/project.json
@@ -21,6 +21,7 @@
   },
   "description": "Stormpath middleware for ASP.NET Core. Easily adds authentication and authorization to ASP.NET Core applications.",
   "frameworks": {
+    "net451": {},
     "netstandard1.6": {
       "imports": "dotnet"
     }


### PR DESCRIPTION
It is possible to build ASP.NET Core applications that target the .NET 4.5 framework. Since this package only targets .NET Standard 1.6 it cannot be imported into ASP.NET Core projects that do so. This results in the following build error:

```
error: Package Stormpath.AspNetCore 0.3.2 is not compatible with net461 (.NETFramework,Version=v4.6.1). Package Stormpath.AspNetCore 0.3.2 supports: netstandard1.6 (.NETStandard,Version=v1.6)
error: One or more packages are incompatible with .NETFramework,Version=v4.6.1.
```

This is a very simple change and is risk free, while broadening the appeal of solution.